### PR TITLE
Fix typo in fruit name from 'Pinapple' to 'Pineapple' in PlantsScreen

### DIFF
--- a/app/(tabs)/plants.tsx
+++ b/app/(tabs)/plants.tsx
@@ -12,7 +12,7 @@ export default function PlantsScreen() {
         <Text style={styles.text}>
           Fruits
             </Text>
-          {['Apple', 'Banana', 'Cherry', 'Pinapple', 'Watermelon', 'Melon'].map((fruit, index) => (
+          {['Apple', 'Banana', 'Cherry', 'Pineapple', 'Watermelon', 'Melon'].map((fruit, index) => (
             <Text key={index} style={styles.items}>
               {fruit}
               <Text> Description</Text>


### PR DESCRIPTION
Fix typo in fruit name from 'Pinapple' to 'Pineapple' in PlantsScreen