### PR TITLE
Fix import statement for Ionicons in PlantsComponent

### DIFF
--- a/components/ui/PlantsComponent.tsx
+++ b/components/ui/PlantsComponent.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StyleSheet, ViewStyle, Pressable, View, Image } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
+import Ionicons from "@expo/vector-icons/Ionicons";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { ThemedText } from "@/components/ThemedText";
 


### PR DESCRIPTION
This pull request includes a small change to the `PlantsComponent.tsx` file. The change updates the import statement for the `Ionicons` module to use a direct path instead of a named import.

* [`components/ui/PlantsComponent.tsx`](diffhunk://#diff-38b27e8c319d56c541f01f655d2994c8b13cd2b857b210c5095deed1dffbcbdfL3-R3): Changed the import statement for `Ionicons` to `import Ionicons from "@expo/vector-icons/Ionicons"` for better compatibility or clarity.