### PR TITLE
Add expo-location dependency to package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "expo-font": "~13.0.4",
         "expo-haptics": "~14.0.1",
         "expo-linking": "~7.0.5",
+        "expo-location": "~18.0.10",
         "expo-router": "~4.0.20",
         "expo-splash-screen": "~0.29.22",
         "expo-status-bar": "~2.0.1",
@@ -8350,6 +8351,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.0.10.tgz",
+      "integrity": "sha512-R0Iioz0UZ9Ts8TACPngh8uDFbajJhVa5/igLqWB8Pq/gp8UHuwj7PC8XbZV7avsFoShYjaxrOhf4U7IONeKLgg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5"
+    "react-native-webview": "13.12.5",
+    "expo-location": "~18.0.10"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` file, adding a new dependency for `expo-location`.

Dependency updates:

* Added `expo-location` version `~18.0.10` to the list of dependencies in `package.json`.