### PR TITLE
Add notification preference toggle

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -2,11 +2,35 @@ import { ThemedSafeAreaView } from "@/components/ThemedSafeAreaView";
 import { ThemedScrollView } from "@/components/ThemedScrollView";
 import { ThemedText } from "@/components/ThemedText";
 import { StatusBar } from "expo-status-bar";
-import React from "react";
-import { View, StyleSheet } from "react-native";
+import React, { useEffect, useState } from "react";
+import { View, StyleSheet, Switch } from "react-native";
+import * as Notifications from "expo-notifications";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 export default function Settings() {
+  const [allowNotifications, setAllowNotifications] = useState(false);
+
+  useEffect(() => {
+    AsyncStorage.getItem("allowNotifications").then((value) => {
+      if (value !== null) {
+        setAllowNotifications(JSON.parse(value));
+      }
+    });
+  }, []);
+
+  const handleToggle = async (value: boolean) => {
+    if (value) {
+      const { status } = await Notifications.requestPermissionsAsync();
+      if (status !== "granted") {
+        setAllowNotifications(false);
+        return;
+      }
+    }
+    setAllowNotifications(value);
+    await AsyncStorage.setItem("allowNotifications", JSON.stringify(value));
+  };
+
   return (
     <SafeAreaProvider>
       <ThemedSafeAreaView>
@@ -15,6 +39,13 @@ export default function Settings() {
         </View>
         <ThemedScrollView>
           <ThemedText style={styles.text}>Settings</ThemedText>
+          <View style={styles.row}>
+            <ThemedText style={styles.label}>Enable Notifications</ThemedText>
+            <Switch
+              value={allowNotifications}
+              onValueChange={handleToggle}
+            />
+          </View>
         </ThemedScrollView>
       </ThemedSafeAreaView>
     </SafeAreaProvider>
@@ -35,5 +66,14 @@ const styles = StyleSheet.create({
   statusBarContainer: {
     borderColor: "#343a40",
     borderBottomWidth: 0.2,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: 12,
+  },
+  label: {
+    fontSize: 16,
   },
 });


### PR DESCRIPTION
## Summary
- add allowNotifications setting toggle
- request notification permissions when enabling
- persist notification preference via AsyncStorage

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f6f4409d0832d9aba40491904dd91