### PR TITLE
Add theme provider with toggleable color scheme

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,12 +1,14 @@
 import { ThemedSafeAreaView } from "@/components/ThemedSafeAreaView";
 import { ThemedScrollView } from "@/components/ThemedScrollView";
 import { ThemedText } from "@/components/ThemedText";
+import { useTheme } from "@/hooks/ThemeProvider";
 import { StatusBar } from "expo-status-bar";
 import React from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Switch } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 export default function Settings() {
+  const { theme, toggleTheme } = useTheme();
   return (
     <SafeAreaProvider>
       <ThemedSafeAreaView>
@@ -15,6 +17,10 @@ export default function Settings() {
         </View>
         <ThemedScrollView>
           <ThemedText style={styles.text}>Settings</ThemedText>
+          <View style={styles.themeRow}>
+            <ThemedText>Dark Mode</ThemedText>
+            <Switch value={theme === "dark"} onValueChange={toggleTheme} />
+          </View>
         </ThemedScrollView>
       </ThemedSafeAreaView>
     </SafeAreaProvider>
@@ -36,4 +42,11 @@ const styles = StyleSheet.create({
     borderColor: "#343a40",
     borderBottomWidth: 0.2,
   },
+  themeRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    padding: 12,
+  },
 });
+

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
 import "react-native-reanimated";
+import { ThemeProvider } from "@/hooks/ThemeProvider";
 
 SplashScreen.preventAutoHideAsync();
 
@@ -21,9 +22,12 @@ export default function RootLayout() {
     return null;
   }
   return (
-    <Stack>
-      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      <Stack.Screen name="+not-found" />
-    </Stack>
+    <ThemeProvider>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="+not-found" />
+      </Stack>
+    </ThemeProvider>
   );
 }
+

--- a/hooks/ThemeProvider.tsx
+++ b/hooks/ThemeProvider.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+type ThemeContextType = {
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextType>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeContext);
+

--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -1,1 +1,7 @@
-export { useColorScheme } from 'react-native';
+import { useTheme } from './ThemeProvider';
+
+export function useColorScheme() {
+  const { theme } = useTheme();
+  return theme;
+}
+

--- a/hooks/useColorScheme.web.ts
+++ b/hooks/useColorScheme.web.ts
@@ -1,21 +1,7 @@
-import { useEffect, useState } from 'react';
-import { useColorScheme as useRNColorScheme } from 'react-native';
+import { useTheme } from './ThemeProvider';
 
-/**
- * To support static rendering, this value needs to be re-calculated on the client side for web
- */
 export function useColorScheme() {
-  const [hasHydrated, setHasHydrated] = useState(false);
-
-  useEffect(() => {
-    setHasHydrated(true);
-  }, []);
-
-  const colorScheme = useRNColorScheme();
-
-  if (hasHydrated) {
-    return colorScheme;
-  }
-
-  return 'light';
+  const { theme } = useTheme();
+  return theme;
 }
+


### PR DESCRIPTION
## Summary
- implement ThemeProvider to manage light/dark modes
- consume theme context via useColorScheme hook
- add theme toggle switch in Settings screen and wrap app in provider

## Testing
- `npm test -- --watchAll=false` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa83a11b0832da9cab6e76e9d39be